### PR TITLE
バリデーションエラーのハンドリング

### DIFF
--- a/backend/app/controllers/api/v1/contacts_controller.rb
+++ b/backend/app/controllers/api/v1/contacts_controller.rb
@@ -35,7 +35,7 @@ class Api::V1::ContactsController < ApplicationController
             ContactMailer.complete.deliver_later
             render json: { contact: contact }, status: 200
         else
-            render json: { errors: contact.errors.to_hash(true) }, status: 422
+            render json: { errors: contact.errors.full_messages }, status: 422
         end
     end
 

--- a/backend/app/controllers/api/v1/knowledges_controller.rb
+++ b/backend/app/controllers/api/v1/knowledges_controller.rb
@@ -25,7 +25,7 @@ class Api::V1::KnowledgesController < ApplicationController
         if knowledge.save
             render json: { knowledge: knowledge }, status: 200
         else
-            render json: { errors: knowledge.errors.to_hash(true) }, status: 422
+            render json: { errors: knowledge.errors.full_messages }, status: 422
         end
     end
 
@@ -58,7 +58,7 @@ class Api::V1::KnowledgesController < ApplicationController
         image = knowledge.images.find(params[:image_id])
         image.purge
 
-        render json: { knowledge: knowledge, imageUrls: knowledge.image_urls }, status: 200
+        render json: { knowledge: knowledge.as_json(methods: :image_urls) }, status: 200
     end
 
     def update

--- a/backend/app/controllers/api/v1/knowledges_controller.rb
+++ b/backend/app/controllers/api/v1/knowledges_controller.rb
@@ -75,7 +75,7 @@ class Api::V1::KnowledgesController < ApplicationController
         if knowledge.update(knowledge_register_params) 
             render json: { knowledge: knowledge }, status: 200
         else
-            render json: { errors: knowledge.errors.to_hash(true) }, status: 422
+            render json: { errors: knowledge.errors.full_messages }, status: 422
         end
     end
 
@@ -93,7 +93,7 @@ class Api::V1::KnowledgesController < ApplicationController
         if knowledge.destroy
             render json: { knowledge: knowledge }, status: 200
         else
-            render json: { errors: knowledges.errors.to_hash(true) }, status: 422
+            render json: { errors: knowledges.errors.full_messages }, status: 422
         end
     end
 

--- a/backend/app/controllers/api/v1/passwords_controller.rb
+++ b/backend/app/controllers/api/v1/passwords_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::PasswordsController < DeviseTokenAuth::PasswordsController
     if @user.update_with_password(password_edit_params)
       render json: { user: @user }, status: 200
     else
-      render json: { errors: @user.errors.to_hash(true) }, status: 422
+      render json: { errors: @user.errors.full_messages }, status: 422
     end
   end
   

--- a/backend/app/controllers/api/v1/profiles_controller.rb
+++ b/backend/app/controllers/api/v1/profiles_controller.rb
@@ -10,14 +10,14 @@ class Api::V1::ProfilesController < ApplicationController
             if @user.profile.update(profile_register_params)
                 render json: { user: @user.profile.as_json(methods: :image_url) }, status: 200
             else
-                render json: { errors: @user.profile.errors.to_hash(true) }, status: 422
+                render json: { errors: @user.profile.errors.full_message }, status: 422
             end
         else
             @user.profile = Profile.new(profile_register_params)
             if @user.profile.save
                 render json: { user: @user.profile.as_json(methods: :image_url) }, status: 200
             else
-                render json: { errors: @user.profile.errors.to_hash(true) }, status: 422
+                render json: { errors: @user.profile.errors.full_message }, status: 422
             end
         end
     end

--- a/backend/app/controllers/api/v1/records_controller.rb
+++ b/backend/app/controllers/api/v1/records_controller.rb
@@ -143,7 +143,7 @@ class Api::V1::RecordsController < ApplicationController
         if @record.destroy
             render json: { record: record }, status: 200
         else
-            render json: { errors: record.errors.to_hash(true) }, status: 422
+            render json: { errors: record.errors.full_message }, status: 422
         end
     end
 

--- a/backend/app/controllers/api/v1/records_controller.rb
+++ b/backend/app/controllers/api/v1/records_controller.rb
@@ -106,7 +106,7 @@ class Api::V1::RecordsController < ApplicationController
         if record.save
             render json: { record: record }, status: 200
         else
-            render json: { errors: record.errors.to_hash(true) }, status: 422
+            render json: { errors: record.errors.full_messages }, status: 422
         end
     end
 

--- a/backend/app/controllers/api/v1/signup_controller.rb
+++ b/backend/app/controllers/api/v1/signup_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::SignupController < DeviseTokenAuth::RegistrationsController
       if @user.update_without_password(sign_up_params)
         render json: { user: @user }, status: 200
       else
-        render json: { errors: @user.errors }, status: 422
+        render json: { errors: @user.errors.full_messages }, status: 422
       end
     else
     end
@@ -24,7 +24,7 @@ class Api::V1::SignupController < DeviseTokenAuth::RegistrationsController
     if @user.destroy
       render status: 200
     else
-      render json: { errors: @user.errors }, status: 422
+      render json: { errors: @user.errors.full_messages }, status: 422
     end
   end
 

--- a/backend/app/controllers/api/v1/supports_controller.rb
+++ b/backend/app/controllers/api/v1/supports_controller.rb
@@ -11,9 +11,9 @@ class Api::V1::SupportsController < ApplicationController
                 ]
             )
             includes_user = user_json["supporters"].any? { |supporter| supporter["id"] == @user.id }
-            render json: { user: user_json, isSupport: includes_user ,status: 200 }
+            render json: { user: user_json, isSupport: includes_user }, status: 200
         else
-            render json: { errors: supporting.erros }, status: 422
+            render json: { errors: supporting.erros.full_messages }, status: 422
         end
     end
 
@@ -32,9 +32,9 @@ class Api::V1::SupportsController < ApplicationController
                 ]
             )
             includes_user = user_json["supporters"].any? { |supporter| supporter["id"] == @user.id }
-            render json: { user: user_json, isSupport: includes_user , status: 200 }
+            render json: { user: user_json, isSupport: includes_user }, status: 200
         else
-            render json: { errors: supporting.erros }, status: 422
+            render json: { errors: supporting.erros.full_messages }, status: 422
         end
     end
 

--- a/backend/config/locales/devise.views.ja.yml
+++ b/backend/config/locales/devise.views.ja.yml
@@ -133,15 +133,35 @@ ja:
       unlocked: アカウントをロック解除しました。
   errors:
     messages:
+      accepted: を受諾してください
       already_confirmed: は既に登録済みです。ログインしてください。
+      blank: を入力してください
+      confirmation: "が一致しません"
       confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
       expired: の有効期限が切れました。新しくリクエストしてください。
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
       not_found: は見つかりませんでした。
       not_locked: はロックされていません。
       not_saved:
         one: エラーが発生したため %{resource} は保存されませんでした。
         other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
-      confirmation: "が一致しません"
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
       too_short: "は%{count}文字以上で入力してください"
-      blank: "を入力してください"
       too_long: "は%{count}文字以内で入力してください"
+      taken: はすでに存在します
+      wrong_length: は%{count}文字で入力してください

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "chart.js": "^4.4.2",
     "js-cookie": "^3.0.5",
     "markdown-it": "^14.1.0",
+    "primeicons": "^7.0.0",
     "primevue": "^3.52.0",
     "vee-validate": "^4.12.7",
     "vue": "^3.4.21",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,10 +14,12 @@
     "chart.js": "^4.4.2",
     "js-cookie": "^3.0.5",
     "markdown-it": "^14.1.0",
+    "vee-validate": "^4.12.7",
     "vue": "^3.4.21",
     "vue-chartjs": "^5.3.1",
     "vue-router": "^4.3.0",
-    "vuejs-paginate-next": "^1.0.2"
+    "vuejs-paginate-next": "^1.0.2",
+    "yup": "^1.4.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "chart.js": "^4.4.2",
     "js-cookie": "^3.0.5",
     "markdown-it": "^14.1.0",
+    "primevue": "^3.52.0",
     "vee-validate": "^4.12.7",
     "vue": "^3.4.21",
     "vue-chartjs": "^5.3.1",

--- a/frontend/src/components/atom/ErrorMessage.vue
+++ b/frontend/src/components/atom/ErrorMessage.vue
@@ -3,10 +3,11 @@ import Message from 'primevue/message';
 import 'primevue/resources/themes/md-light-indigo/theme.css';
 
 const prop = defineProps(['errorMessage'])
+
 </script>
 
 <template>
-    <Message severity="error" v-if="prop.errorMessage !== ''" class="error-message">{{ prop.errorMessage }}</Message>
+    <Message severity="error" v-show="prop.errorMessage !== ''" class="error-message" :closable="false">{{ prop.errorMessage }}</Message>
 </template>
 
 <style scoped>

--- a/frontend/src/components/atom/ErrorMessage.vue
+++ b/frontend/src/components/atom/ErrorMessage.vue
@@ -1,0 +1,17 @@
+<script setup>
+import Message from 'primevue/message';
+import 'primevue/resources/themes/md-light-indigo/theme.css';
+
+const prop = defineProps(['errorMessage'])
+</script>
+
+<template>
+    <Message severity="error" v-if="prop.errorMessage !== ''" class="error-message">{{ prop.errorMessage }}</Message>
+</template>
+
+<style scoped>
+.error-message {
+    white-space:pre-wrap; 
+    word-wrap:break-word;
+}
+</style>

--- a/frontend/src/components/page/AccountIntroduction.vue
+++ b/frontend/src/components/page/AccountIntroduction.vue
@@ -3,7 +3,11 @@ import { useRouter } from 'vue-router'
 import axios from 'axios'
 import Cookies from 'js-cookie'
 
+import ErrorMessage from '../atom/ErrorMessage.vue'
+
 const router = useRouter();
+
+const errorMessage = ref('');
 
 function showSignup() {
     router.push('/signup');
@@ -22,13 +26,21 @@ const guestLogin = async () => {
 
     router.push({ name: 'Home'})
   } catch (error) {
-    console.log({ error })
+    errorMessage.value = ''
+    let errorMessages = 'ゲストログインに失敗しました\n';
+    if (error.response.status === 422) {
+        if (Array.isArray(error.response.data.errors)) {
+            errorMessages += error.response.data.errors.join('\n');
+        }
+    }
+    errorMessage.value = errorMessages
   }
 }
 </script>
 
 <template>
     <h1 class="homeTitle">理想の体を手に入れよう！</h1>
+    <ErrorMessage :errorMessage="errorMessage"/>
     <div class="homeContents">
         <div class="homeImage">
             <img src="../../assets/image/home_image.jpg" alt="Logo" class= "homeLogo">

--- a/frontend/src/components/page/AddKnowledge.vue
+++ b/frontend/src/components/page/AddKnowledge.vue
@@ -5,10 +5,12 @@ import Cookies from 'js-cookie';
 
 import DropFile from '../atom/DropFile.vue'
 import Header from '../layout/Header.vue'
+import ErrorMessage from '../atom/ErrorMessage.vue'
 
 const title = ref("");
 const knowledge = ref("");
 const files = ref([]);
+const errorMessage = ref('');
 
 function dateChange(event) {
     recordDate.value = event
@@ -18,8 +20,9 @@ function onFileChange(event) {
     files.value = [...event];
 }
 
-const registerRecord = async () => {
-  try {
+const registerKnowledge = async () => {
+    errorMessage.value = ''
+    try {
         const formData = new FormData();
         formData.append('knowledge[title]', title.value);
         formData.append('knowledge[content]', knowledge.value);
@@ -38,13 +41,21 @@ const registerRecord = async () => {
         })
         console.log({ res })
     } catch (error) {
-        console.log({ error })
+        errorMessage.value = ''
+        let errorMessages = 'ノウハウの追加に失敗しました\n';
+        if (error.response.status === 422) {
+            if (Array.isArray(error.response.data.errors)) {
+                errorMessages += error.response.data.errors.join('\n');
+            }
+        }
+        errorMessage.value = errorMessages
     }
 }
 </script>
 
 <template>
     <Header />
+    <ErrorMessage :errorMessage="errorMessage"/>
     <div class="editor">
         <label class="itemLabel">タイトル</label>
         <input id="title" type="text" v-model="title">
@@ -55,7 +66,7 @@ const registerRecord = async () => {
         <DropFile @change="onFileChange"/>
     </div>
     <div class="relationImages">
-        <button class="registerButton" @click="registerRecord">登録する</button>
+        <button class="registerButton" @click="registerKnowledge">登録する</button>
     </div>
 </template>
 

--- a/frontend/src/components/page/AddRecord.vue
+++ b/frontend/src/components/page/AddRecord.vue
@@ -6,6 +6,7 @@ import Cookies from 'js-cookie';
 import DatePicker from '../atom/DatePicker.vue'
 import DropFile from '../atom/DropFile.vue'
 import Header from '../layout/Header.vue'
+import ErrorMessage from '../atom/ErrorMessage.vue'
 
 const memo = ref("");
 const recordDate = ref("");
@@ -13,6 +14,7 @@ const weight = ref(null);
 const fatPercentage = ref(null);
 const files = ref([]);
 const isAddAsHidden = ref(false);
+const errorMessage = ref('');
 
 function dateChange(event) {
     recordDate.value = event
@@ -48,13 +50,21 @@ const registerRecord = async () => {
         })
         console.log({ res })
     } catch (error) {
-        console.log({ error })
+        errorMessage.value = ''
+        let errorMessages = '記録の追加に失敗しました\n';
+        if (error.response.status === 422) {
+            if (Array.isArray(error.response.data.errors)) {
+                errorMessages += error.response.data.errors.join('\n');
+            }
+        }
+        errorMessage.value = errorMessages
     }
 }
 </script>
 
 <template>
     <Header />
+    <ErrorMessage :errorMessage="errorMessage"/>
     <div class="time-list">
         <div class="item">
             <p class="inputTitle">記録日</p>

--- a/frontend/src/components/page/Contact.vue
+++ b/frontend/src/components/page/Contact.vue
@@ -4,8 +4,10 @@ import { ref } from 'vue'
 import Cookies from 'js-cookie'
 
 import Header from '../layout/Header.vue'
+import ErrorMessage from '../atom/ErrorMessage.vue'
 
 const contact = ref('')
+const errorMessage = ref('');
 
 const contactSubmit = async () => {
     try {
@@ -21,13 +23,21 @@ const contactSubmit = async () => {
         })
         console.log({ res })
     } catch (error) {
-        console.log({ error })
+        errorMessage.value = ''
+        let errorMessages = 'お問合せ送信に失敗しました\n';
+        if (error.response.status === 422) {
+            if (Array.isArray(error.response.data.errors)) {
+                errorMessages += error.response.data.errors.join('\n');
+            }
+        }
+        errorMessage.value = errorMessages
     }
 }
 </script>
 
 <template>
     <Header />
+    <ErrorMessage :errorMessage="errorMessage"/>
     <h1 class="signUpTitle">お問合せ</h1>
     <div class="contact-area">
         <form class="contact-form" @submit.prevent="contactSubmit">

--- a/frontend/src/components/page/EditKnowledge.vue
+++ b/frontend/src/components/page/EditKnowledge.vue
@@ -6,6 +6,7 @@ import Cookies from 'js-cookie';
 
 import DropFile from '../atom/DropFile.vue'
 import Header from '../layout/Header.vue'
+import ErrorMessage from '../atom/ErrorMessage.vue'
 
 const route = useRoute();
 const router = useRouter();
@@ -15,6 +16,7 @@ const knowledge = ref("");
 const files = ref([]);
 const imageUrls = ref([]);
 const knowledgeId = ref(null);
+const errorMessage = ref('');
 
 onMounted(() => {
     getDetail();
@@ -47,7 +49,14 @@ const deleteImage = async (item) => {
         })
         console.log({ res })
     } catch (error) {
-        console.log({ error })
+        errorMessage.value = ''
+        let errorMessages = '画像の削除に失敗しました\n';
+        if (error.response.status === 422) {
+            if (Array.isArray(error.response.data.errors)) {
+                errorMessages += error.response.data.errors.join('\n');
+            }
+        }
+        errorMessage.value = errorMessages
     }
 }
 
@@ -97,6 +106,15 @@ const edit = async () => {
     } catch (error) {
         if (error.response.status === 404) {
             showNotFound()
+        } else {
+            errorMessage.value = ''
+            let errorMessages = 'ノウハウの編集に失敗しました\n';
+            if (error.response.status === 422) {
+                if (Array.isArray(error.response.data.errors)) {
+                    errorMessages += error.response.data.errors.join('\n');
+                }
+            }
+            errorMessage.value = errorMessages
         }
     }
 }
@@ -104,6 +122,7 @@ const edit = async () => {
 
 <template>
     <Header />
+    <ErrorMessage :errorMessage="errorMessage"/>
     <div class="editor">
         <label class="itemLabel">タイトル</label>
         <input id="title" type="text" v-model="title">

--- a/frontend/src/components/page/EditProfile.vue
+++ b/frontend/src/components/page/EditProfile.vue
@@ -6,6 +6,7 @@ import Cookies from 'js-cookie';
 
 import DropFile from '../atom/DropFile.vue'
 import Header from '../layout/Header.vue'
+import ErrorMessage from '../atom/ErrorMessage.vue'
 
 const route = useRoute();
 
@@ -15,6 +16,7 @@ const profile = ref('');
 const file = ref(null);
 const userThumbnail = ref(null);
 const userId = ref(0);
+const errorMessage = ref('');
 
 function onFileChange(event) {
     file.value = event[0];
@@ -74,13 +76,21 @@ const updateProfile = async () => {
         })
         
     } catch (error) {
-        console.log({ error })
+        errorMessage.value = ''
+        let errorMessages = 'プロフィール変更に失敗しました\n';
+        if (error.response.status === 422) {
+            if (Array.isArray(error.response.data.errors)) {
+                errorMessages += error.response.data.errors.join('\n');
+            }
+        }
+        errorMessage.value = errorMessages
     }
 }
 </script>
 
 <template>
     <Header />
+    <ErrorMessage :errorMessage="errorMessage"/>
     <form @submit.prevent="updateProfile">
         <div class="profile-edit-content">
             <label for="goal-weight">目標体重:</label>

--- a/frontend/src/components/page/Login.vue
+++ b/frontend/src/components/page/Login.vue
@@ -3,13 +3,19 @@ import axios from 'axios'
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import Cookies from 'js-cookie'
+import { useField, useForm } from 'vee-validate';
+import * as yup from 'yup';
 
 import Header from '../layout/Header.vue'
 
 const router = useRouter();
 
-const email = ref('')
-const password = ref('')
+const handleSubmit = async () => {
+  const result = await validate()
+  if (result.valid) {
+    login()
+  }
+}
 
 const login = async () => {
   try {
@@ -26,20 +32,38 @@ const login = async () => {
     console.log({ error })
   }
 }
+
+const schema = yup.object({
+  password: yup
+    .string()
+    .required("この項目は必須です")
+    .min(6, "6文字以上で入力してください")
+    .max(128, "128文字以下で入力してください"),
+  email: yup
+    .string()
+    .required("この項目は必須です")
+    .email("メールアドレスの形式で入力してください"),
+});
+
+const { validate } = useForm({ validationSchema: schema })
+const { value: password, errorMessage: passwordError } = useField('password');
+const { value: email, errorMessage: emailError } = useField('email');
 </script>
 
 <template>
     <Header />
     <h1 class="signUpTitle">ログイン</h1>
     <div class="singUpInput">
-        <form class="form" @submit.prevent="login">
+        <form class="form" @submit.prevent="handleSubmit">
             <div class="item">
                 <label class="itemLabel">メールアドレス</label>
                 <input id="email" type="email" v-model="email">
+                <p class="validation-error-message">{{ emailError }}</p>
             </div>
             <div class="item">
                 <label class="itemLabel" for="password">パスワード</label>
                 <input id="password" type="password" v-model="password">
+                <p class="validation-error-message">{{ passwordError }}</p>
             </div>
             <div class="signUpTitle">
                 <button class="loginButton">ログイン</button>

--- a/frontend/src/components/page/Login.vue
+++ b/frontend/src/components/page/Login.vue
@@ -7,6 +7,9 @@ import { useField, useForm } from 'vee-validate';
 import * as yup from 'yup';
 
 import Header from '../layout/Header.vue'
+import ErrorMessage from '../atom/ErrorMessage.vue'
+
+const errorMessage = ref('');
 
 const router = useRouter();
 
@@ -29,7 +32,13 @@ const login = async () => {
 
     router.push({ name: 'Home'})
   } catch (error) {
-    console.log({ error })
+    let errorMessages = 'ログインに失敗しました\n';
+    if (error.response.status === 401) {
+        if (Array.isArray(error.response.data.errors)) {
+            errorMessages += error.response.data.errors.join('\n');
+        }
+    }
+    errorMessage.value = errorMessages
   }
 }
 
@@ -53,6 +62,7 @@ const { value: email, errorMessage: emailError } = useField('email');
 <template>
     <Header />
     <h1 class="signUpTitle">ログイン</h1>
+    <ErrorMessage :errorMessage="errorMessage"/>
     <div class="singUpInput">
         <form class="form" @submit.prevent="handleSubmit">
             <div class="item">
@@ -94,11 +104,6 @@ const { value: email, errorMessage: emailError } = useField('email');
 .itemLabel{
     display: block;
     text-align: left;
-}
-
-.error-message{
-    width: 50%;
-    margin: 0 auto;
 }
  
 .error-message-text{

--- a/frontend/src/components/page/MailAddressEdit.vue
+++ b/frontend/src/components/page/MailAddressEdit.vue
@@ -93,11 +93,6 @@ const { value: newMailAddres, errorMessage: emailError } = useField('newMailAddr
     display: block;
     text-align: left;
 }
-
-.error-message{
-    width: 50%;
-    margin: 0 auto;
-}
  
 .error-message-text{
     color: red;

--- a/frontend/src/components/page/MailAddressEdit.vue
+++ b/frontend/src/components/page/MailAddressEdit.vue
@@ -6,6 +6,9 @@ import { useField, useForm } from 'vee-validate';
 import * as yup from 'yup';
 
 import Header from '../layout/Header.vue'
+import ErrorMessage from '../atom/ErrorMessage.vue'
+
+const errorMessage = ref('');
 
 const checkValidate = async () => {
   const result = await validate()
@@ -32,7 +35,14 @@ const mailAddressEdit = async () => {
         Cookies.set('client', res.headers["client"])
         Cookies.set('uid', res.headers["uid"])
     } catch (error) {
-        console.log({ error })
+        errorMessage.value = ''
+        let errorMessages = 'メールアドレス変更に失敗しました\n';
+        if (error.response.status === 422) {
+            if (Array.isArray(error.response.data.errors)) {
+                errorMessages += error.response.data.errors.join('\n');
+            }
+        }
+        errorMessage.value = errorMessages
     }
 }
 
@@ -55,6 +65,7 @@ const { value: newMailAddres, errorMessage: emailError } = useField('newMailAddr
 
 <template>
     <Header />
+    <ErrorMessage :errorMessage="errorMessage"/>
     <h1 class="signUpTitle">メールアドレス変更</h1>
     <div class="singUpInput">
         <form class="form" @submit.prevent="checkValidate">

--- a/frontend/src/components/page/MailAddressEdit.vue
+++ b/frontend/src/components/page/MailAddressEdit.vue
@@ -2,10 +2,17 @@
 import axios from 'axios'
 import { ref } from 'vue'
 import Cookies from 'js-cookie'
+import { useField, useForm } from 'vee-validate';
+import * as yup from 'yup';
 
 import Header from '../layout/Header.vue'
 
-const newMailAddres = ref('')
+const checkValidate = async () => {
+  const result = await validate()
+  if (result.valid) {
+    mailAddressEdit()
+  }
+}
 
 const mailAddressEdit = async () => {
     try {
@@ -28,16 +35,33 @@ const mailAddressEdit = async () => {
         console.log({ error })
     }
 }
+
+const schema = yup.object({
+  newMailAddres: yup
+    .string()
+    .required("この項目は必須です")
+    .email("メールアドレスの形式で入力してください")
+});
+
+const { validate } = useForm({
+  validationSchema: schema,
+  initialValues: {
+    newMailAddres: ''
+  }
+})
+
+const { value: newMailAddres, errorMessage: emailError } = useField('newMailAddres');
 </script>
 
 <template>
     <Header />
     <h1 class="signUpTitle">メールアドレス変更</h1>
     <div class="singUpInput">
-        <form class="form" @submit.prevent="mailAddressEdit">
+        <form class="form" @submit.prevent="checkValidate">
             <div class="item">
                 <label class="itemLabel" for="email">変更後のメールアドレス</label>
                 <input id="email" type="email" v-model="newMailAddres">
+                <p class="validation-error-message">{{ emailError }}</p>
             </div>
             <div class="signUpTitle">
                 <button class="registerButton">更新</button>

--- a/frontend/src/components/page/PasswordEdit.vue
+++ b/frontend/src/components/page/PasswordEdit.vue
@@ -115,10 +115,6 @@ const { value: currentPassword, errorMessage: currentPasswordError } = useField(
     text-align: left;
 }
 
-.error-message{
-    width: 50%;
-    margin: 0 auto;
-}
  
 .error-message-text{
     color: red;

--- a/frontend/src/components/page/PasswordEdit.vue
+++ b/frontend/src/components/page/PasswordEdit.vue
@@ -6,6 +6,9 @@ import { useField, useForm } from 'vee-validate';
 import * as yup from 'yup';
 
 import Header from '../layout/Header.vue'
+import ErrorMessage from '../atom/ErrorMessage.vue'
+
+const errorMessage = ref('');
 
 const checkValidate = async () => {
   const result = await validate()
@@ -31,7 +34,14 @@ const passwordEdit = async () => {
         })
         console.log({ res })
     } catch (error) {
-        console.log({ error })
+        errorMessage.value = ''
+        let errorMessages = 'パスワード変更に失敗しました\n';
+        if (error.response.status === 422) {
+            if (Array.isArray(error.response.data.errors)) {
+                errorMessages += error.response.data.errors.join('\n');
+            }
+        }
+        errorMessage.value = errorMessages
     }
 }
 
@@ -69,6 +79,7 @@ const { value: currentPassword, errorMessage: currentPasswordError } = useField(
 
 <template>
     <Header />
+    <ErrorMessage :errorMessage="errorMessage"/>
     <h1 class="signUpTitle">パスワード変更</h1>
     <div class="singUpInput">
         <form class="form" @submit.prevent="checkValidate">

--- a/frontend/src/components/page/PasswordEdit.vue
+++ b/frontend/src/components/page/PasswordEdit.vue
@@ -2,13 +2,17 @@
 import axios from 'axios'
 import { ref } from 'vue'
 import Cookies from 'js-cookie'
+import { useField, useForm } from 'vee-validate';
+import * as yup from 'yup';
 
 import Header from '../layout/Header.vue'
 
-const currentPassword = ref('')
-const password = ref('')
-const passwordConfirm = ref('')
-const name = ref('')
+const checkValidate = async () => {
+  const result = await validate()
+  if (result.valid) {
+    passwordEdit()
+  }
+}
 
 const passwordEdit = async () => {
     try {
@@ -30,13 +34,44 @@ const passwordEdit = async () => {
         console.log({ error })
     }
 }
+
+const schema = yup.object({
+  password: yup
+    .string()
+    .required("この項目は必須です")
+    .min(6, "6文字以上で入力してください")
+    .max(128, "128文字以下で入力してください"),
+  passwordConfirm: yup
+    .string()
+    .required("この項目は必須です")
+    .min(6, "6文字以上で入力してください")
+    .max(128, "128文字以下で入力してください"),
+  currentPassword: yup
+    .string()
+    .required("この項目は必須です")
+    .min(6, "6文字以上で入力してください")
+    .max(128, "128文字以下で入力してください")
+});
+
+const { validate } = useForm({
+  validationSchema: schema,
+  initialValues: {
+    password: '',
+    passwordConfirm: '',
+    currentPassword: ''
+  }
+})
+
+const { value: password, errorMessage: passwordError } = useField('password');
+const { value: passwordConfirm, errorMessage: passwordConfirmError } = useField('passwordConfirm');
+const { value: currentPassword, errorMessage: currentPasswordError } = useField('currentPassword');
 </script>
 
 <template>
     <Header />
     <h1 class="signUpTitle">パスワード変更</h1>
     <div class="singUpInput">
-        <form class="form" @submit.prevent="passwordEdit">
+        <form class="form" @submit.prevent="checkValidate">
             <div class="item">
                 <label class="itemLabel" for="password">現在のパスワード</label>
                 <input id="currentPassword" type="password" v-model="currentPassword">

--- a/frontend/src/components/page/RecordDetail.vue
+++ b/frontend/src/components/page/RecordDetail.vue
@@ -6,6 +6,7 @@ import Cookies from 'js-cookie';
 import MarkdownIt from 'markdown-it'
 
 import Header from '../layout/Header.vue'
+import ErrorMessage from '../atom/ErrorMessage.vue'
 
 const route = useRoute();
 const router = useRouter();
@@ -19,6 +20,7 @@ const isMyRecord = ref(false);
 const isSupport = ref(false);
 const comments = ref([]);
 const comment = ref('');
+const errorMessage = ref('');
 
 const md = new MarkdownIt()
 
@@ -70,6 +72,15 @@ const deleteRecord = async () => {
     } catch (error) {
         if (error.response.status === 404) {
             showNotFound()
+        } else {
+            errorMessage.value = ''
+            let errorMessages = '記録削除に失敗しました\n';
+            if (error.response.status === 422) {
+                if (Array.isArray(error.response.data.errors)) {
+                    errorMessages += error.response.data.errors.join('\n');
+                }
+            }
+            errorMessage.value = errorMessages
         }
     }
 }
@@ -91,6 +102,15 @@ const supportOn = async () => {
     } catch (error) {
         if (error.response.status === 404) {
             showNotFound()
+        } else {
+            errorMessage.value = ''
+            let errorMessages = '応援に失敗しました\n';
+            if (error.response.status === 422) {
+                if (Array.isArray(error.response.data.errors)) {
+                    errorMessages += error.response.data.errors.join('\n');
+                }
+            }
+            errorMessage.value = errorMessages
         }
     }
 }
@@ -108,6 +128,15 @@ const supportOff = async () => {
     } catch (error) {
         if (error.response.status === 404) {
             showNotFound()
+        } else {
+            errorMessage.value = ''
+            let errorMessages = '応援解除に失敗しました\n';
+            if (error.response.status === 422) {
+                if (Array.isArray(error.response.data.errors)) {
+                    errorMessages += error.response.data.errors.join('\n');
+                }
+            }
+            errorMessage.value = errorMessages
         }
     }
 }
@@ -152,6 +181,7 @@ function edit() {
 
 <template>
     <Header />
+    <ErrorMessage :errorMessage="errorMessage"/>
     <div class="wrap">
 		<div class="main">
 			<div class="main_content">

--- a/frontend/src/components/page/Setting.vue
+++ b/frontend/src/components/page/Setting.vue
@@ -5,12 +5,14 @@ import axios from 'axios';
 import Cookies from 'js-cookie'
 
 import Header from '../layout/Header.vue'
+import ErrorMessage from '../atom/ErrorMessage.vue'
 
 const router = useRouter();
 
 const isLogin = ref(false);
 const userId = ref(0);
 const showModal = ref(false);
+const errorMessage = ref('');
 
 onMounted(() => {
     checkLogin();
@@ -48,7 +50,14 @@ const deleteAccount = async () => {
         
     router.push({ name: 'Home'})
   } catch (error) {
-    console.log({ error })
+    errorMessage.value = ''
+    let errorMessages = 'ノウハウの編集に失敗しました\n';
+    if (error.response.status === 422) {
+      if (Array.isArray(error.response.data.errors)) {
+        errorMessages += error.response.data.errors.join('\n');
+      }
+    }
+    errorMessage.value = errorMessages
   }
 }
 
@@ -75,6 +84,7 @@ function closeModal() {
 
 <template>
   <Header />
+  <ErrorMessage :errorMessage="errorMessage"/>
   <div class="setting-list">
     <span class="section-title">プロフィール変更</span>
     <p class="section-message">目標体重や紹介文を編集できます</p>

--- a/frontend/src/components/page/Signup.vue
+++ b/frontend/src/components/page/Signup.vue
@@ -130,11 +130,6 @@ const { value: name, errorMessage: nameError } = useField('name');
     display: block;
     text-align: left;
 }
-
-.error-message{
-    width: 50%;
-    margin: 0 auto;
-}
  
 .error-message-text{
     color: red;

--- a/frontend/src/components/page/Signup.vue
+++ b/frontend/src/components/page/Signup.vue
@@ -7,8 +7,11 @@ import { useField, useForm } from 'vee-validate';
 import * as yup from 'yup';
 
 import Header from '../layout/Header.vue'
+import ErrorMessage from '../atom/ErrorMessage.vue'
 
 const router = useRouter();
+
+const errorMessage = ref('');
 
 defineProps({
   msg: String,
@@ -35,7 +38,13 @@ const signup = async () => {
 
     router.push({ name: 'Home'})
   } catch (error) {
-    console.log({ error })
+    let errorMessages = '会員登録に失敗しました\n';
+    if (error.response.status === 422) {
+        if (Array.isArray(error.response.data.errors.full_messages)) {
+            errorMessages += error.response.data.errors.full_messages.join('\n');
+        }
+    }
+    errorMessage.value = errorMessages
   }
 }
 
@@ -78,6 +87,7 @@ const { value: name, errorMessage: nameError } = useField('name');
 <template>
     <Header />
     <h1 class="signUpTitle">会員登録</h1>
+    <ErrorMessage :errorMessage="errorMessage"/>
     <div class="singUpInput">
         <form class="form" @submit.prevent="checkValidate">
             <div class="item">

--- a/frontend/src/components/page/Signup.vue
+++ b/frontend/src/components/page/Signup.vue
@@ -3,6 +3,8 @@ import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import Cookies from 'js-cookie'
 import axios from 'axios'
+import { useField, useForm } from 'vee-validate';
+import * as yup from 'yup';
 
 import Header from '../layout/Header.vue'
 
@@ -12,10 +14,12 @@ defineProps({
   msg: String,
 })
 
-const email = ref('')
-const password = ref('')
-const passwordConfirm = ref('')
-const name = ref('')
+const checkValidate = async () => {
+  const result = await validate()
+  if (result.valid) {
+    signup()
+  }
+}
 
 const signup = async () => {
   try {
@@ -34,28 +38,67 @@ const signup = async () => {
     console.log({ error })
   }
 }
+
+const schema = yup.object({
+  password: yup
+    .string()
+    .required("この項目は必須です")
+    .min(6, "6文字以上で入力してください")
+    .max(128, "128文字以下で入力してください"),
+  passwordConfirm: yup
+    .string()
+    .required("この項目は必須です")
+    .min(6, "6文字以上で入力してください")
+    .max(128, "128文字以下で入力してください"),
+  email: yup
+    .string()
+    .required("この項目は必須です")
+    .email("メールアドレスの形式で入力してください"),
+  name: yup
+    .string()
+    .required("この項目は必須です"),
+});
+
+const { validate } = useForm({
+  validationSchema: schema,
+  initialValues: {
+    password: '',
+    passwordConfirm: '',
+    email: '',
+    name: ''
+  }
+})
+
+const { value: password, errorMessage: passwordError } = useField('password');
+const { value: passwordConfirm, errorMessage: passwordConfirmError } = useField('passwordConfirm');
+const { value: email, errorMessage: emailError } = useField('email');
+const { value: name, errorMessage: nameError } = useField('name');
 </script>
 
 <template>
     <Header />
     <h1 class="signUpTitle">会員登録</h1>
     <div class="singUpInput">
-        <form class="form" @submit.prevent="signup">
+        <form class="form" @submit.prevent="checkValidate">
             <div class="item">
                 <label class="itemLabel">メールアドレス</label>
                 <input id="email" type="email" v-model="email">
+                <p class="validation-error-message">{{ emailError }}</p>
             </div>
             <div class="item">
                 <label class="itemLabel" for="password">パスワード</label>
                 <input id="password" type="password" v-model="password">
+                <p class="validation-error-message">{{ passwordError }}</p>
             </div>
             <div class="item">
                 <label class="itemLabel" for="passwordConfirm">パスワード(確認)</label>
                 <input id="passwordConfirm" type="password" v-model="passwordConfirm">
+                <p class="validation-error-message">{{ passwordConfirmError }}</p>
             </div>
             <div class="item">
                 <label class="itemLabel" for="name">名前</label>
                 <input id="name"  type="text" v-model="name">
+                <p class="validation-error-message">{{ nameError }}</p>
             </div>
             <div class="signUpTitle">
                 <button class="registerButton">登録</button>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2,5 +2,12 @@ import { createApp } from 'vue'
 import './style.css'
 import App from './App.vue'
 import router from './router'
+import PrimeVue from 'primevue/config';
+import 'primevue/resources/primevue.min.css'
+import 'primeicons/primeicons.css'
 
-createApp(App).use(router).mount('#app')
+
+const app = createApp(App);
+app.use(router);
+app.use(PrimeVue);
+app.mount('#app');

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -59,6 +59,10 @@ textarea {
   padding: 2em;
 }
 
+p.validation-error-message {
+  color:red;
+}
+
 #app {
   margin: 0 auto;
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -34,14 +34,14 @@ h1 {
 
 button {
   border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
+  border: 0px solid transparent;
+  /* padding: 0.6em 1.2em; */
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  /* background-color: #1a1a1a; */
   cursor: pointer;
-  transition: border-color 0.25s;
+  /* transition: border-color 0.25s; */
 }
 button:hover {
 }
@@ -75,7 +75,7 @@ p.validation-error-message {
   a:hover {
     color: #f58505;
   }
-  button {
+  /* button {
     background-color: #f9f9f9;
-  }
+  } */
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -318,7 +318,7 @@
     "@vue/compiler-dom" "3.4.25"
     "@vue/shared" "3.4.25"
 
-"@vue/devtools-api@^6.5.1":
+"@vue/devtools-api@^6.5.1", "@vue/devtools-api@^6.6.1":
   version "6.6.1"
   resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.6.1.tgz#7c14346383751d9f6ad4bea0963245b30220ef83"
   integrity sha512-LgPscpE3Vs0x96PzSSB4IGVSZXZBZHpfxs+ZA1d+VEPwHdOXowy/Y2CsvCAIFrf+ssVU1pD1jidj505EpUnfbA==
@@ -795,6 +795,11 @@ postcss@^8.4.35, postcss@^8.4.36, postcss@^8.4.38:
     picocolors "^1.0.0"
     source-map-js "^1.2.0"
 
+property-expr@^2.0.5:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.6.tgz#f77bc00d5928a6c748414ad12882e83f24aec1e8"
+  integrity sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -895,10 +900,38 @@ strip-ansi@^7.0.1:
   dependencies:
     ansi-regex "^6.0.1"
 
+tiny-case@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
+  integrity sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
+
+type-fest@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
+
+type-fest@^4.8.3:
+  version "4.18.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.18.2.tgz#8d765c42e7280a11f4d04fb77a00dacc417c8b05"
+  integrity sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==
+
 uc.micro@^2.0.0, uc.micro@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"
   integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
+
+vee-validate@^4.12.7:
+  version "4.12.7"
+  resolved "https://registry.yarnpkg.com/vee-validate/-/vee-validate-4.12.7.tgz#9eb2ac9e5d6e3c8b4425db04f2ac7d30c1ff40a0"
+  integrity sha512-1BGql4XNu/3TqHFjBLV6OrZ4fRteHXxRc9tLF5Q40IgIo1cwYEyaccC1AL3tdFUr2E3JsYhXbiEExoUSy4C9nA==
+  dependencies:
+    "@vue/devtools-api" "^6.6.1"
+    type-fest "^4.8.3"
 
 vite@^5.2.0:
   version "5.2.2"
@@ -987,3 +1020,13 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yup@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.4.0.tgz#898dcd660f9fb97c41f181839d3d65c3ee15a43e"
+  integrity sha512-wPbgkJRCqIf+OHyiTBQoJiP5PFuAXaWiJK6AmYkzQAh5/c2K9hzSApBZG5wV9KoKSePF7sAxmNSvh/13YHkFDg==
+  dependencies:
+    property-expr "^2.0.5"
+    tiny-case "^1.0.3"
+    toposort "^2.0.2"
+    type-fest "^2.19.0"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -795,6 +795,11 @@ postcss@^8.4.35, postcss@^8.4.36, postcss@^8.4.38:
     picocolors "^1.0.0"
     source-map-js "^1.2.0"
 
+primevue@^3.52.0:
+  version "3.52.0"
+  resolved "https://registry.yarnpkg.com/primevue/-/primevue-3.52.0.tgz#819d1d70fe37cea7dcd06076b7c3cd9ee4e3c6a4"
+  integrity sha512-HLOVP5YI0ArFKUhIyfZsWmTNMaBYNCBWC/3DYvdd/Po4LY5/WXf7yIYvArE2q/3OuwSXJXvjlR8UNQeJYRSQog==
+
 property-expr@^2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.6.tgz#f77bc00d5928a6c748414ad12882e83f24aec1e8"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -795,6 +795,11 @@ postcss@^8.4.35, postcss@^8.4.36, postcss@^8.4.38:
     picocolors "^1.0.0"
     source-map-js "^1.2.0"
 
+primeicons@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/primeicons/-/primeicons-7.0.0.tgz#6b25c3fdcb29bb745a3035bdc1ed5902f4a419cf"
+  integrity sha512-jK3Et9UzwzTsd6tzl2RmwrVY/b8raJ3QZLzoDACj+oTJ0oX7L9Hy+XnVwgo4QVKlKpnP/Ur13SXV/pVh4LzaDw==
+
 primevue@^3.52.0:
   version "3.52.0"
   resolved "https://registry.yarnpkg.com/primevue/-/primevue-3.52.0.tgz#819d1d70fe37cea7dcd06076b7c3cd9ee4e3c6a4"


### PR DESCRIPTION
- veevalidateの追加でInputタグのみで構成されている画面(会員登録やログインなど)はバリデーションチェックをAPI実行前に行う
- バリデーションルールはyapで定義
- APIのエラーが発生した場合にはエラーメッセージを表示させる