### PR TITLE
ダークモードの考慮追加

### DIFF
--- a/frontend/src/components/page/knowledge/AddKnowledge.vue
+++ b/frontend/src/components/page/knowledge/AddKnowledge.vue
@@ -20,7 +20,7 @@
         rel="noopener noreferrer"
         class="info-link"
         >こちら</a
-      >をご覧ください。<br>
+      >をご覧ください。<br />
       特に複数行の改行は使うことが多いと思うので必ずご確認ください
     </div>
   </div>
@@ -69,10 +69,16 @@ const registerKnowledge = async () => {
     formData.append("knowledge[content]", knowledge.value);
 
     for (const file of files.value) {
-      formData.append("knowledge[images]", file);
+      if (file != null) {
+        formData.append("knowledge[images][]", file);
+      }
     }
 
-    const res = await axiosInstance.post("/api/v1/knowledges", formData);
+    const res = await axiosInstance.post("/api/v1/knowledges", formData, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    });
     toastNotifications.displayInfo("登録しました", "");
     setTimeout(async () => {
       showKnowledgeDetail(res.data.knowledge);

--- a/frontend/src/components/page/knowledge/KnowledgeDetail.vue
+++ b/frontend/src/components/page/knowledge/KnowledgeDetail.vue
@@ -21,7 +21,7 @@
           <p class="knowledge-content" v-html="renderedMarkdown" />
         </div>
         <div v-if="imageUrls.length !== 0">
-          <p class="mt-5">関連画像</p>
+          <p class="mt-6">関連画像(画像タップで拡大表示できます)</p>
           <div class="thumbnail-container">
             <div class="thumbnail" v-for="item in imageUrls">
               <RelationImage :item="item" />

--- a/frontend/src/components/page/record/RecordDetail.vue
+++ b/frontend/src/components/page/record/RecordDetail.vue
@@ -31,7 +31,7 @@
             {{ record != null && record.memo != null ? record.memo : "" }}
           </p>
           <div v-if="imageUrls !== null && imageUrls.length !== 0">
-            <p class="mt-5">関連画像</p>
+            <p class="mt-5">関連画像(画像タップで拡大表示できます)</p>
             <div class="thumbnail-container">
               <div class="thumbnail" v-for="item in imageUrls">
                 <RelationImage :item="item" />

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -150,3 +150,13 @@ p.validation-error-message {
     color: #ffa500;
   }
 }
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color: #213547;
+    background-color: #ffffff;
+  }
+  a:hover {
+    color: #ffa500;
+  }
+}

--- a/frontend/src/test/Header.spec.js
+++ b/frontend/src/test/Header.spec.js
@@ -74,7 +74,7 @@ describe('Header.vue', () => {
     mockedAxiosInstance = axiosModule.axiosInstance;
     mockedAxiosInstance.get.mockResolvedValueOnce({ data: { user: null } })
 
-    expect(wrapper.find('.account-introducton-button').exists()).toBe(true)
+    expect(wrapper.find('.account-introduction-button').exists()).toBe(true)
   })
 
   it('ログイン済みの場合には会員登録・ログインボタンが表示されない', async () => {
@@ -97,7 +97,7 @@ describe('Header.vue', () => {
     mockedAxiosInstance = axiosModule.axiosInstance;
     mockedAxiosInstance.get.mockResolvedValue({ data: { user: user } })
 
-    expect(wrapper.find('.user-button').exists()).toBe(true)
+    expect(wrapper.find('.account-introduction-button').exists()).toBe(true)
   })
 
   it('ログイン済みの場合にはドロップダウンメニューが4つ表示される', async () => {

--- a/frontend/src/test/__snapshots__/EditKnowledge.spec.js.snap
+++ b/frontend/src/test/__snapshots__/EditKnowledge.spec.js.snap
@@ -70,6 +70,10 @@ exports[`EditKnowledge SnapShotテスト初期表示 1`] = `
             label=""
           />
         </div>
+        <p
+          class="text-center mt-2.5"
+        />
+        <!--v-if-->
       </div>
       <div
         class="thumbnail"
@@ -91,6 +95,10 @@ exports[`EditKnowledge SnapShotテスト初期表示 1`] = `
             label=""
           />
         </div>
+        <p
+          class="text-center mt-2.5"
+        />
+        <!--v-if-->
       </div>
       
     </div>

--- a/frontend/src/test/__snapshots__/EditRecord.spec.js.snap
+++ b/frontend/src/test/__snapshots__/EditRecord.spec.js.snap
@@ -92,6 +92,7 @@ exports[`EditRecord SnapShotテスト初期表示 1`] = `
               label=""
             />
           </div>
+          <!--v-if-->
         </div>
         <div
           class="thumbnail"
@@ -113,6 +114,7 @@ exports[`EditRecord SnapShotテスト初期表示 1`] = `
               label=""
             />
           </div>
+          <!--v-if-->
         </div>
         
       </div>

--- a/frontend/src/test/__snapshots__/Header.spec.js.snap
+++ b/frontend/src/test/__snapshots__/Header.spec.js.snap
@@ -15,7 +15,7 @@ exports[`Header.vue SnapShotテスト 1`] = `
       class="navigation-menus"
     >
       <button
-        class="account-introducton-button mr-7"
+        class="account-introduction-button mr-7"
         style=""
       >
          会員登録・ログイン 

--- a/frontend/src/test/__snapshots__/KnowledgeDetail.spec.js.snap
+++ b/frontend/src/test/__snapshots__/KnowledgeDetail.spec.js.snap
@@ -47,9 +47,9 @@ exports[`EditKnowledge SnapShotテスト初期表示(コメントあり) 1`] = `
         </div>
         <div>
           <p
-            class="mt-5"
+            class="mt-6"
           >
-            関連画像
+            関連画像(画像タップで拡大表示できます)
           </p>
           <div
             class="thumbnail-container"
@@ -211,9 +211,9 @@ exports[`EditKnowledge SnapShotテスト初期表示(コメントなし) 1`] = `
         </div>
         <div>
           <p
-            class="mt-5"
+            class="mt-6"
           >
-            関連画像
+            関連画像(画像タップで拡大表示できます)
           </p>
           <div
             class="thumbnail-container"

--- a/frontend/src/test/__snapshots__/KnowledgeList.spec.js.snap
+++ b/frontend/src/test/__snapshots__/KnowledgeList.spec.js.snap
@@ -7,7 +7,7 @@ exports[`KnowledgeList SnapShotテスト初期表示(データあり) 1`] = `
   
   <header-stub />
   <tab-menu-stub
-    currentid="3"
+    currentid="4"
   />
   <div
     class="knowledge-search-container"
@@ -139,7 +139,7 @@ exports[`KnowledgeList SnapShotテスト初期表示(データなし) 1`] = `
   
   <header-stub />
   <tab-menu-stub
-    currentid="3"
+    currentid="4"
   />
   <div
     class="knowledge-search-container"

--- a/frontend/src/test/__snapshots__/MyRecordList.spec.js.snap
+++ b/frontend/src/test/__snapshots__/MyRecordList.spec.js.snap
@@ -5,6 +5,10 @@ exports[`MyRecordList SnapShotテスト初期表示(データあり) 1`] = `
   data-v-app=""
 >
   
+  <header-stub />
+  <tab-menu-stub
+    currentid="2"
+  />
   <div
     class="record-search-container"
   >
@@ -117,6 +121,10 @@ exports[`UserList SnapShotテスト初期表示(データなし) 1`] = `
   data-v-app=""
 >
   
+  <header-stub />
+  <tab-menu-stub
+    currentid="2"
+  />
   <div
     class="record-search-container"
   >

--- a/frontend/src/test/__snapshots__/OtherRecordList.spec.js.snap
+++ b/frontend/src/test/__snapshots__/OtherRecordList.spec.js.snap
@@ -7,7 +7,7 @@ exports[`OtherRecordList SnapShotテスト初期表示(データあり) 1`] = `
   
   <header-stub />
   <tab-menu-stub
-    currentid="2"
+    currentid="3"
   />
   <div
     class="record-search-container"
@@ -103,7 +103,7 @@ exports[`OtherRecordList SnapShotテスト初期表示(データなし) 1`] = `
   
   <header-stub />
   <tab-menu-stub
-    currentid="2"
+    currentid="3"
   />
   <div
     class="record-search-container"

--- a/frontend/src/test/__snapshots__/RecordDetail.spec.js.snap
+++ b/frontend/src/test/__snapshots__/RecordDetail.spec.js.snap
@@ -48,7 +48,7 @@ exports[`RecordDetail SnapShotテスト初期表示(コメントあり) 1`] = `
             <p
               class="mt-5"
             >
-              関連画像
+              関連画像(画像タップで拡大表示できます)
             </p>
             <div
               class="thumbnail-container"
@@ -205,7 +205,7 @@ exports[`RecordDetail SnapShotテスト初期表示(コメントなし) 1`] = `
             <p
               class="mt-5"
             >
-              関連画像
+              関連画像(画像タップで拡大表示できます)
             </p>
             <div
               class="thumbnail-container"
@@ -362,7 +362,7 @@ exports[`RecordDetail SnapShotテスト初期表示(自分以外の記録)) 1`] 
             <p
               class="mt-5"
             >
-              関連画像
+              関連画像(画像タップで拡大表示できます)
             </p>
             <div
               class="thumbnail-container"

--- a/frontend/src/test/__snapshots__/UserList.spec.js.snap
+++ b/frontend/src/test/__snapshots__/UserList.spec.js.snap
@@ -7,7 +7,7 @@ exports[`UserList SnapShotテスト初期表示(データあり) 1`] = `
   
   <header-stub />
   <tab-menu-stub
-    currentid="2"
+    currentid="3"
   />
   <div
     class="user-search-container"
@@ -129,7 +129,7 @@ exports[`UserList SnapShotテスト初期表示(データなし) 1`] = `
   
   <header-stub />
   <tab-menu-stub
-    currentid="2"
+    currentid="3"
   />
   <div
     class="user-search-container"


### PR DESCRIPTION
- ダークモードの時はライトモードと同じ表示にする
- 記録・記事詳細画面で画像をタップしたら拡大表示できることを表記する
- 記事登録でContent-Typeの指定を消してしまっていたので復活させる