### PR TITLE
ユーザーのサムネイルを登録するときに画像を縮小して登録する

### DIFF
--- a/backend/app/controllers/api/v1/signup_controller.rb
+++ b/backend/app/controllers/api/v1/signup_controller.rb
@@ -13,6 +13,15 @@ class Api::V1::SignupController < DeviseTokenAuth::RegistrationsController
       render json: { errors: current_api_v1_user.errors.full_messages }, status: :unprocessable_entity
     end
 
+    if account_update_params[:image].present?
+      processed_image = ImageProcessing::MiniMagick
+        .source(account_update_params[:image])
+        .resize_to_limit(100, 100)
+        .call
+  
+      account_update_params[:image] = processed_image
+    end
+
     render json: { user: current_api_v1_user }, status: :ok
   end
 


### PR DESCRIPTION
サムネイルのロードが遅く感じることがあるので登録の際に画像サイズを縮小して登録する