### PR TITLE
会員登録のフォームの見直し

### DIFF
--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -17,8 +17,9 @@ class Api::V1::UsersController < ApplicationController
                    .group("users.id")
                    .select("users.*, COUNT(supports.id) AS supporters_count")
                    .order("supporters_count DESC")
+                   .latest_users
             else
-              users.order(created_at: :desc)
+              users.latest_users
             end
 
     users = if params[:page].present?

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -36,6 +36,8 @@ class User < ActiveRecord::Base
             size: { less_than: 5.megabytes },
             allow_blank: true
 
+  scope :latest_users, -> { order(created_at: :desc) }
+
   def image_url
     return unless image.attached?
 

--- a/frontend/src/components/page/account/AccountIntroduction.vue
+++ b/frontend/src/components/page/account/AccountIntroduction.vue
@@ -38,9 +38,9 @@ const showLogin = () => {
 const guestLogin = async () => {
   try {
     const res = await axiosInstance.post("/api/v1/users/guest_sign_in");
-    Cookies.set("accessToken", res.headers["access-token"], { expires: 365 });
-    Cookies.set("client", res.headers["client"], { expires: 365 });
-    Cookies.set("uid", res.headers["uid"], { expires: 365 });
+    Cookies.set("accessToken", res.headers["access-token"], { expires: 14 });
+    Cookies.set("client", res.headers["client"], { expires: 14 });
+    Cookies.set("uid", res.headers["uid"], { expires: 14 });
 
     if (
       Cookies.get("loginRoutePath") != null &&

--- a/frontend/src/components/page/account/Login.vue
+++ b/frontend/src/components/page/account/Login.vue
@@ -1,8 +1,8 @@
 <template>
   <Header />
   <Toast position="top-center" />
-  <h1 class="view-title mt-7">ログイン</h1>
-  <div class="login-container">
+  <h1 class="title_line view-title container-width mt-7">ログイン</h1>
+  <div class="login-container container-width mt-5">
     <form class="form" @submit.prevent="handleSubmit">
       <div class="login-item">
         <label>メールアドレス</label>
@@ -110,12 +110,15 @@ const showHome = () => {
 
 <style scoped>
 .login-container {
-  width: 500px;
-  margin: 0 auto;
   padding: 20px;
   background-color: #ffffff;
   border: 1px solid #ccc;
   border-radius: 5px;
+}
+.container-width {
+  width: 500px;
+  margin-left: auto;
+  margin-right: auto;
 }
 .login-item {
   padding-top: 40px;
@@ -145,6 +148,12 @@ const showHome = () => {
     background-color: #ffffff;
     border: 1px solid #ccc;
     border-radius: 5px;
+  }
+
+  .container-width {
+    width: auto;
+    margin-left: 20px;
+    margin-right: 20px;
   }
 }
 </style>

--- a/frontend/src/components/page/account/Login.vue
+++ b/frontend/src/components/page/account/Login.vue
@@ -1,7 +1,7 @@
 <template>
   <Header />
   <Toast position="top-center" />
-  <h1 class="title_line view-title container-width mt-7">ログイン</h1>
+  <p class="title-line view-title container-width mt-7">ログイン</p>
   <div class="login-container container-width mt-5">
     <form class="form" @submit.prevent="handleSubmit">
       <div class="login-item">

--- a/frontend/src/components/page/account/MailAddressEdit.vue
+++ b/frontend/src/components/page/account/MailAddressEdit.vue
@@ -5,7 +5,7 @@
   <div class="setting-container">
     <SettingSideMenu :currentIndex="2" />
     <main>
-      <p class="title_line pt-10">メールアドレス変更</p>
+      <p class="title-line pt-10">メールアドレス変更</p>
       <div class="mailaddress-edit-container">
         <form class="form" @submit.prevent="checkValidate">
           <div class="pt-10">

--- a/frontend/src/components/page/account/MailAddressEdit.vue
+++ b/frontend/src/components/page/account/MailAddressEdit.vue
@@ -112,6 +112,7 @@ const { value: newMailAddres, errorMessage: emailError } =
   width: 500px;
   margin: 0 auto;
   padding: 20px;
+  margin-top: 20px;
   background-color: #ffffff;
   border: 1px solid #ccc;
   border-radius: 5px;

--- a/frontend/src/components/page/account/PasswordEdit.vue
+++ b/frontend/src/components/page/account/PasswordEdit.vue
@@ -5,7 +5,7 @@
   <div class="setting-container">
     <SettingSideMenu :currentIndex="3" />
     <main>
-      <p class="title_line pt-10">パスワード変更</p>
+      <p class="title-line pt-10">パスワード変更</p>
       <div class="password-edit-container">
         <form class="form" @submit.prevent="checkValidate">
           <div class="pt-10">

--- a/frontend/src/components/page/account/Signup.vue
+++ b/frontend/src/components/page/account/Signup.vue
@@ -3,7 +3,7 @@
   <Toast position="top-center" />
   <p class="view-title mt-7">会員登録</p>
   <div class="signup-container">
-    <form class="form" @submit.prevent="checkValidate">
+    <form class="form" @submit.prevent @keydown.enter.prevent>
       <div class="signup-item">
         <label>メールアドレス</label>
         <input id="email" type="email" v-model="email" />
@@ -33,7 +33,7 @@
         <p class="validation-error-message">{{ nameError }}</p>
       </div>
       <div class="text-center mt-5">
-        <button class="signup-button">登録</button>
+        <button class="signup-button" @click="checkValidate">登録</button>
       </div>
     </form>
   </div>

--- a/frontend/src/components/page/account/Signup.vue
+++ b/frontend/src/components/page/account/Signup.vue
@@ -1,8 +1,8 @@
 <template>
   <Header />
   <Toast position="top-center" />
-  <p class="view-title mt-7">会員登録</p>
-  <div class="signup-container">
+  <p class="title_line view-title container-width mt-7">会員登録</p>
+  <div class="signup-container container-width pt-5 mt-5">
     <form class="form" @submit.prevent @keydown.enter.prevent>
       <div class="signup-item">
         <label>メールアドレス</label>
@@ -73,9 +73,9 @@ const signup = async () => {
       password_confirmation: passwordConfirm.value,
       name: name.value,
     });
-    Cookies.set("accessToken", res.headers["access-token"], { expires: 365 });
-    Cookies.set("client", res.headers["client"], { expires: 365 });
-    Cookies.set("uid", res.headers["uid"], { expires: 365 });
+    Cookies.set("accessToken", res.headers["access-token"], { expires: 14 });
+    Cookies.set("client", res.headers["client"], { expires: 14 });
+    Cookies.set("uid", res.headers["uid"], { expires: 14 });
 
     router.push({ name: "Home" });
   } catch (error) {
@@ -136,12 +136,15 @@ const updatePassword = (inputPassword, passwordType) => {
 
 <style scoped>
 .signup-container {
-  width: 500px;
-  margin: 0 auto;
   padding: 20px;
   background-color: #ffffff;
   border: 1px solid #ccc;
   border-radius: 5px;
+}
+.container-width {
+  width: 500px;
+  margin-left: auto;
+  margin-right: auto;
 }
 .signup-item {
   padding-top: 40px;
@@ -161,13 +164,16 @@ const updatePassword = (inputPassword, passwordType) => {
 
 @media screen and (max-width: 768px) {
   .signup-container {
-    width: auto;
-    margin-left: 20px;
-    margin-right: 20px;
     padding: 20px;
     background-color: #ffffff;
     border: 1px solid #ccc;
     border-radius: 5px;
+  }
+
+  .container-width {
+    width: auto;
+    margin-left: 20px;
+    margin-right: 20px;
   }
 }
 </style>

--- a/frontend/src/components/page/account/Signup.vue
+++ b/frontend/src/components/page/account/Signup.vue
@@ -1,7 +1,7 @@
 <template>
   <Header />
   <Toast position="top-center" />
-  <p class="title_line view-title container-width mt-7">会員登録</p>
+  <p class="title-line view-title container-width mt-7">会員登録</p>
   <div class="signup-container container-width pt-5 mt-5">
     <form class="form" @submit.prevent @keydown.enter.prevent>
       <div class="signup-item">

--- a/frontend/src/components/page/contact/Contact.vue
+++ b/frontend/src/components/page/contact/Contact.vue
@@ -2,7 +2,7 @@
   <Header />
   <TabMenu />
   <Toast position="top-center" />
-  <p class="title_line mt-5">お問合せ</p>
+  <p class="title-line mt-5">お問合せ</p>
   <div class="contact-container mt-5 pb-8">
     <form class="contact-form" @submit.prevent="contactSubmit">
       <div class="contact-item">

--- a/frontend/src/components/page/contact/ContactList.vue
+++ b/frontend/src/components/page/contact/ContactList.vue
@@ -2,7 +2,7 @@
   <Header />
   <TabMenu />
   <Toast position="top-center" />
-  <p class="title_line mt-5">お問合せ一覧</p>
+  <p class="title-line mt-5">お問合せ一覧</p>
   <p class="mt-5 mx-5 text-lg">
     対応済みのお問い合わせは次の日には表示されなくなるのでご注意ください
   </p>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -100,7 +100,7 @@ p.validation-error-message {
   z-index: 9999;
 }
 /* タイトルの装飾(1文字目を大きくして色を変える) */
-.title_line {
+.title-line {
   font-weight: bold;
   border-bottom: 2px solid #ffa500;
   padding: 0.3em;
@@ -108,7 +108,7 @@ p.validation-error-message {
   margin-left: 20px;
   margin-right: 20px;
 }
-.title_line:first-letter {
+.title-line:first-letter {
   font-size: 1.5em;
   color: #ffa500;
 }

--- a/frontend/src/test/__snapshots__/Contact.spec.js.snap
+++ b/frontend/src/test/__snapshots__/Contact.spec.js.snap
@@ -11,7 +11,7 @@ exports[`Contact SnapShotテスト初期表示 1`] = `
     position="top-center"
   />
   <p
-    class="title_line mt-5"
+    class="title-line mt-5"
   >
     お問合せ
   </p>

--- a/frontend/src/test/__snapshots__/Login.spec.js.snap
+++ b/frontend/src/test/__snapshots__/Login.spec.js.snap
@@ -9,13 +9,13 @@ exports[`Login SnapShotテスト初期表示 1`] = `
   <toast-stub
     position="top-center"
   />
-  <h1
-    class="view-title mt-7"
+  <p
+    class="title-line view-title container-width mt-7"
   >
     ログイン
-  </h1>
+  </p>
   <div
-    class="login-container"
+    class="login-container container-width mt-5"
   >
     <form
       class="form"

--- a/frontend/src/test/__snapshots__/PasswordEdit.spec.js.snap
+++ b/frontend/src/test/__snapshots__/PasswordEdit.spec.js.snap
@@ -18,7 +18,7 @@ exports[`PasswordEdit.vue SnapShotテスト 1`] = `
     />
     <main>
       <p
-        class="title_line pt-10"
+        class="title-line pt-10"
       >
         パスワード変更
       </p>

--- a/frontend/src/test/__snapshots__/SignUp.spec.js.snap
+++ b/frontend/src/test/__snapshots__/SignUp.spec.js.snap
@@ -10,12 +10,12 @@ exports[`SignUp SnapShotテスト初期表示 1`] = `
     position="top-center"
   />
   <p
-    class="view-title mt-7"
+    class="title-line view-title container-width mt-7"
   >
     会員登録
   </p>
   <div
-    class="signup-container"
+    class="signup-container container-width pt-5 mt-5"
   >
     <form
       class="form"


### PR DESCRIPTION
- 会員登録はエンターで処理を行わずボタンタップのみで行うようにする
- 応援しているユーザーが多い順でユーザーのソートをした後に作成順に並び替える
- 会員登録、ログインのタイトルを装飾する